### PR TITLE
Feat/#27 Backend Rabbitmq (SpringBoot와 RabbitMQ 연결)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
 	annotationProcessor 'org.projectlombok:lombok'
 
 	// jsoup 의존성 추가

--- a/backend/src/main/java/com/rollthedice/backend/domain/crawling/NewsCrawlingService.java
+++ b/backend/src/main/java/com/rollthedice/backend/domain/crawling/NewsCrawlingService.java
@@ -1,6 +1,6 @@
 package com.rollthedice.backend.domain.crawling;
 
-import com.rollthedice.backend.domain.dto.NewsUrlDto;
+import com.rollthedice.backend.domain.news.dto.NewsUrlDto;
 import com.rollthedice.backend.domain.news.entity.News;
 import com.rollthedice.backend.domain.news.service.NewsCategory;
 import com.rollthedice.backend.domain.news.service.NewsService;
@@ -37,6 +37,7 @@ public class NewsCrawlingService {
                 scrapNewsContentsAndUpdate(categoryName, news);
             }
         }
+        newsService.summarizeNewsContent();
     }
 
     private void scrapNewsUrls(String categoryUrl) throws IOException {

--- a/backend/src/main/java/com/rollthedice/backend/domain/news/contentqueue/ContentProducer.java
+++ b/backend/src/main/java/com/rollthedice/backend/domain/news/contentqueue/ContentProducer.java
@@ -1,0 +1,26 @@
+package com.rollthedice.backend.domain.news.contentqueue;
+
+import com.rollthedice.backend.domain.news.dto.ContentMessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ContentProducer {
+    @Value("${rabbitmq.summary.exchange.name}")
+    private String exchangeName;
+
+    @Value("${rabbitmq.summary.routing.key}")
+    private String routingKey;
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void sendMessage(ContentMessageDto messageDto) {
+        log.info("publish news content message : {}", messageDto.getId());
+        rabbitTemplate.convertAndSend(exchangeName, routingKey, messageDto);
+    }
+}

--- a/backend/src/main/java/com/rollthedice/backend/domain/news/contentqueue/SummarizedContentConsumer.java
+++ b/backend/src/main/java/com/rollthedice/backend/domain/news/contentqueue/SummarizedContentConsumer.java
@@ -1,0 +1,21 @@
+package com.rollthedice.backend.domain.news.contentqueue;
+
+import com.rollthedice.backend.domain.news.dto.ContentMessageDto;
+import com.rollthedice.backend.domain.news.service.NewsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class SummarizedContentConsumer {
+    private final NewsService newsService;
+
+    @RabbitListener(queues = "${rabbitmq.store.queue.name}")
+    public void receiveMessage(ContentMessageDto messageDto) {
+        log.info("Received summarized news message id: {}", messageDto.getId());
+        newsService.updateSummarizedNews(messageDto);
+    }
+}

--- a/backend/src/main/java/com/rollthedice/backend/domain/news/dto/ContentMessageDto.java
+++ b/backend/src/main/java/com/rollthedice/backend/domain/news/dto/ContentMessageDto.java
@@ -1,0 +1,12 @@
+package com.rollthedice.backend.domain.news.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ContentMessageDto {
+    private Long id;
+    private String content;
+}

--- a/backend/src/main/java/com/rollthedice/backend/domain/news/dto/NewsUrlDto.java
+++ b/backend/src/main/java/com/rollthedice/backend/domain/news/dto/NewsUrlDto.java
@@ -1,4 +1,4 @@
-package com.rollthedice.backend.domain.dto;
+package com.rollthedice.backend.domain.news.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/src/main/java/com/rollthedice/backend/domain/news/service/NewsService.java
+++ b/backend/src/main/java/com/rollthedice/backend/domain/news/service/NewsService.java
@@ -1,13 +1,17 @@
 package com.rollthedice.backend.domain.news.service;
 
-import com.rollthedice.backend.domain.dto.NewsUrlDto;
+import com.rollthedice.backend.domain.news.contentqueue.ContentProducer;
+import com.rollthedice.backend.domain.news.dto.ContentMessageDto;
+import com.rollthedice.backend.domain.news.dto.NewsUrlDto;
 import com.rollthedice.backend.domain.news.entity.News;
 import com.rollthedice.backend.domain.news.repository.NewsRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -15,6 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NewsService {
     private final NewsRepository newsRepository;
+    private final ContentProducer contentProducer;
 
     @Transactional
     public void addNews(NewsUrlDto dto) {
@@ -26,4 +31,18 @@ public class NewsService {
         return newsRepository.findAll();
     }
 
+    @Transactional
+    public void updateSummarizedNews(ContentMessageDto messageDto) {
+        News news = newsRepository.findById(messageDto.getId())
+                .orElseThrow(EntityNotFoundException::new);
+        news.updateSummarizedContent(messageDto.getContent());
+    }
+
+    @Transactional(readOnly = true)
+    public void summarizeNewsContent() {
+        List<ContentMessageDto> messages = new ArrayList<>();
+        newsRepository.findAll().forEach(n ->
+                messages.add(new ContentMessageDto(n.getId(), n.getContent())));
+        messages.forEach(contentProducer::sendMessage);
+    }
 }

--- a/backend/src/main/java/com/rollthedice/backend/global/config/RabbitMQConfig.java
+++ b/backend/src/main/java/com/rollthedice/backend/global/config/RabbitMQConfig.java
@@ -1,0 +1,100 @@
+package com.rollthedice.backend.global.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    @Value("${spring.rabbitmq.host}")
+    private String rabbitmqHost;
+
+    @Value("${spring.rabbitmq.port}")
+    private int rabbitmqPort;
+
+    @Value("${spring.rabbitmq.username}")
+    private String rabbitmqUsername;
+
+    @Value("${spring.rabbitmq.password}")
+    private String rabbitmqPassword;
+
+    @Value("${rabbitmq.summary.queue.name}")
+    private String summaryQueueName;
+
+    @Value("${rabbitmq.store.queue.name}")
+    private String storeQueueName;
+
+    @Value("${rabbitmq.summary.exchange.name}")
+    private String summaryExchangeName;
+
+    @Value(("${rabbitmq.store.exchange.name}"))
+    private String storeExchangeName;
+
+    @Value("${rabbitmq.summary.routing.key}")
+    private String summaryRoutingKey;
+
+    @Value("${rabbitmq.store.routing.key}")
+    private String storeRoutingKey;
+
+    @Bean
+    public Queue summaryQueue() {
+        return new Queue(summaryQueueName);
+    }
+
+    @Bean
+    public Queue storeQueue() {
+        return new Queue(storeQueueName);
+    }
+
+    @Bean
+    public DirectExchange summaryExchange() {
+        return new DirectExchange(summaryExchangeName);
+    }
+
+    @Bean
+    public DirectExchange storeExchange() {
+        return new DirectExchange(storeExchangeName);
+    }
+
+    @Bean
+    public Binding summaryBinding(Queue summaryQueue, DirectExchange summaryExchange) {
+        return BindingBuilder.bind(summaryQueue).to(summaryExchange).with(summaryRoutingKey);
+    }
+
+    @Bean
+    public Binding storeBinding(Queue storeQueue, DirectExchange storeExchange) {
+        return BindingBuilder.bind(storeQueue).to(storeExchange).with(storeRoutingKey);
+    }
+
+    @Bean
+    public ConnectionFactory connectionFactory() {
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+        connectionFactory.setHost(rabbitmqHost);
+        connectionFactory.setPort(rabbitmqPort);
+        connectionFactory.setUsername(rabbitmqUsername);
+        connectionFactory.setPassword(rabbitmqPassword);
+        return connectionFactory;
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public MessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+}


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #27 

### ⚡️ 작업동기

- 뉴스 내용 요약을 위한 GPT OPENAI API 호출에 대한 처리 시간이 길어 비동기 처리를 하기 위해 구현하게 되었습니다.

### 🔑 주요 변경사항

- RabbitMQ 관련 설정을 했습니다. (RabbitMQConfig 구현)
- 크롤링한 뉴스 내용을 RabbitMQ에 Publish합니다. (ContentProducer 구현)
- 요약된 뉴스 내용을 Consumer를 통해 받아 DB에 저장합니다. (SummarizedContentConsumer 구현)

### 💡 관련 이슈

close #27 