### PR TITLE
Fix/#56 FastAPI와 RabbitMQ 스트림 연결 끊기는 현상 예외처리

### DIFF
--- a/backend/ai_response_processor/news/crud/news_summarizer.py
+++ b/backend/ai_response_processor/news/crud/news_summarizer.py
@@ -17,7 +17,7 @@ def summarize_news(news_id: int, content: str):
 
     template = ChatPromptTemplate.from_messages(
         [
-            ("system", "You're a news summarizer. Also, the answer must be no more than 500 characters in Korean."),
+            ("system", "You're a news summarizer. Also, the answer must be summarized in Korean within 30% of the user's request."),
             ("user", "{raw_news_content}"),
         ]
     )


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #56 

### ⚡️ 작업동기

- 많은 양의 데이터를 처리하며 FastAPI와 RabbitMQ의 연결이 끊김

### 🔑 주요 변경사항

- AI Response Processor의 RabbitMQProducer와 RabbitMQConsumer에 예외처리 로직 추가

### 💡 관련 이슈

close #56 