### PR TITLE
Fix/#109 회원 정보 중복 저장 해결

### DIFF
--- a/backend/core/src/main/java/com/rollthedice/backend/global/oauth2/service/AuthService.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/global/oauth2/service/AuthService.java
@@ -34,7 +34,7 @@ public class AuthService {
 
     private Member findOrElseRegisterMember(OAuth2UserInfo userInfo, SocialType socialType) {
         return memberRepository.findBySocialTypeAndOauthId(socialType, userInfo.getId())
-                .orElse(registerMember(socialType, userInfo));
+                .orElseGet(() -> registerMember(socialType, userInfo));
     }
 
     private Member registerMember(SocialType socialType, OAuth2UserInfo userInfo) {


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #109 

### ⚡️ 작업동기

- 회원 정보 중복 저장 해결

### 🔑 주요 변경사항

- 회원 정보 중복 저장하는 로직을 기존 정보를 가져오도록 변경했습니다.

### 💡 관련 이슈

close #109 