### PR TITLE
Fix/#141 회원 정보 저장 및 닉네임 업데이트 로직 수정

### DIFF
--- a/backend/core/src/main/java/com/rollthedice/backend/domain/member/api/MemberController.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/member/api/MemberController.java
@@ -16,19 +16,6 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController implements MemberApi{
     private final MemberService memberService;
 
-    @PostMapping("")
-    public ResponseEntity<HttpStatus> updateMember(@LoginMemberEmail String email,
-                                                   @RequestBody MemberUpdateDto memberUpdateDto) {
-        MemberServiceDto memberServiceDto = memberUpdateDto.toServiceDto(email);
-
-        if (memberService.isDuplicatedNickname(memberServiceDto)) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
-        }
-        memberService.update(memberServiceDto);
-
-        return ResponseEntity.status(HttpStatus.OK).build();
-    }
-
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("")
     @Override

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/member/service/MemberService.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.rollthedice.backend.domain.member.service;
 
 import com.rollthedice.backend.domain.member.dto.MemberServiceDto;
+import com.rollthedice.backend.domain.member.dto.MemberUpdateDto;
 import com.rollthedice.backend.domain.member.dto.response.MemberResponse;
 import com.rollthedice.backend.domain.member.entity.Member;
 import com.rollthedice.backend.domain.member.exception.MemberNotFoundException;
@@ -11,9 +12,11 @@ import com.rollthedice.backend.global.security.jwt.service.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class MemberService {
@@ -27,8 +30,9 @@ public class MemberService {
     }
 
     @Transactional
-    public void update(MemberServiceDto memberServiceDto) {
-        findByEmail(memberServiceDto.getEmail()).update(memberServiceDto);
+    public void update(MemberUpdateDto memberUpdateDto) {
+        Member loginMember = authService.getMember();
+        loginMember.signUp(memberUpdateDto.getNickname());
     }
 
     @Transactional(readOnly = true)

--- a/backend/core/src/main/java/com/rollthedice/backend/global/oauth2/OAuthAttributes.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/global/oauth2/OAuthAttributes.java
@@ -41,7 +41,7 @@ public class OAuthAttributes {
                 .email(oauth2UserInfo.getEmail())
                 .nickname(oauth2UserInfo.getNickname())
                 .imageUrl(oauth2UserInfo.getImageUrl())
-                .role(Role.GUEST)
+                .role(Role.USER)
                 .status(Status.ACTIVE)
                 .build();
     }

--- a/backend/core/src/main/java/com/rollthedice/backend/global/oauth2/controller/AuthController.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/global/oauth2/controller/AuthController.java
@@ -1,23 +1,38 @@
 package com.rollthedice.backend.global.oauth2.controller;
 
+import com.rollthedice.backend.domain.member.dto.MemberUpdateDto;
+import com.rollthedice.backend.domain.member.service.MemberService;
+import com.rollthedice.backend.global.annotation.LoginMemberEmail;
 import com.rollthedice.backend.global.oauth2.dto.LoginRequest;
 import com.rollthedice.backend.global.oauth2.service.AuthService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final MemberService memberService;
 
     @PostMapping("/login")
     public ResponseEntity<HttpStatus> login(@RequestBody LoginRequest request, HttpServletResponse response) {
         authService.authenticateOrRegisterUser(request, response);
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+    @PostMapping("/oauth2/sign-up")
+    public ResponseEntity<HttpStatus> updateMember(@LoginMemberEmail String email,
+                                                   @RequestBody MemberUpdateDto memberUpdateDto) {
+        memberService.update(memberUpdateDto);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
 }

--- a/backend/core/src/main/java/com/rollthedice/backend/global/oauth2/service/AuthService.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/global/oauth2/service/AuthService.java
@@ -41,8 +41,8 @@ public class AuthService {
         Member member = Member.builder()
                 .socialType(socialType)
                 .oauthId(userInfo.getId())
-                .email(UUID.randomUUID() + "@socialUser.com")
-                .nickname(String.valueOf(UUID.randomUUID()))
+                .email(userInfo.getEmail())
+                .nickname(userInfo.getNickname())
                 .imageUrl(userInfo.getImageUrl())
                 .role(Role.USER)
                 .build();
@@ -51,10 +51,9 @@ public class AuthService {
     }
 
     public Member getMember() {
-
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        return memberRepository.findByEmail(userDetails.getUsername()).orElseThrow(MemberNotFoundException::new);
+        String username = authentication.getName();
+        return memberRepository.findByEmail(username).orElseThrow(MemberNotFoundException::new);
     }
 
 }


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #141 

### ⚡️ 작업동기

- 회원가입 시, 잘못된 회원 정보 저장됨

### 🔑 주요 변경사항

- 카카오에서 받은 값대로 회원 정보 저장
- 닉네임 업데이트 api 경로 수정

### 💡 관련 이슈

close #141 