### PR TITLE
Refactor/#166 ReadNews와 News 도메인 분리

### DIFF
--- a/backend/core/src/main/java/com/rollthedice/backend/domain/news/api/NewsApi.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/news/api/NewsApi.java
@@ -46,18 +46,4 @@ public interface NewsApi {
             @Parameter(in = ParameterIn.PATH, description = "뉴스 ID", required = true)
             Long newsId
     );
-
-    @Operation(
-            summary = "최근 읽은 뉴스 조회",
-            description = "가장 최근에 읽은 3개의 뉴스를 조회합니다.",
-            security = {@SecurityRequirement(name = "access_token")},
-            tags = {"news"}
-    )
-    @ApiResponse(
-            responseCode = "200",
-            description = "요청에 성공하였습니다."
-    )
-    List<ReadNewsResponse> getReadNews();
-
-
 }

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/news/api/NewsController.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/news/api/NewsController.java
@@ -2,9 +2,7 @@ package com.rollthedice.backend.domain.news.api;
 
 import com.rollthedice.backend.domain.news.dto.response.NewsDetailResponse;
 import com.rollthedice.backend.domain.news.dto.response.NewsResponse;
-import com.rollthedice.backend.domain.news.dto.response.ReadNewsResponse;
 import com.rollthedice.backend.domain.news.service.NewsService;
-import com.rollthedice.backend.domain.news.service.ReadNewsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -17,7 +15,6 @@ import java.util.List;
 @RequestMapping("news")
 public class NewsController implements NewsApi {
     private final NewsService newsService;
-    private final ReadNewsService readNewsService;
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("")
@@ -28,13 +25,8 @@ public class NewsController implements NewsApi {
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/{newsId}")
+    @Override
     public NewsDetailResponse getDetailNews(final @PathVariable Long newsId) {
         return newsService.getDetailNews(newsId);
-    }
-
-    @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/viewed-history")
-    public List<ReadNewsResponse> getReadNews() {
-        return readNewsService.getReadNews();
     }
 }

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/news/repository/ReadNewsRepository.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/news/repository/ReadNewsRepository.java
@@ -1,7 +1,7 @@
 package com.rollthedice.backend.domain.news.repository;
 
 import com.rollthedice.backend.domain.member.entity.Member;
-import com.rollthedice.backend.domain.news.entity.ReadNews;
+import com.rollthedice.backend.domain.readNews.entity.ReadNews;
 import com.rollthedice.backend.domain.statistics.repository.ReadNewsCustomRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/news/service/NewsService.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/news/service/NewsService.java
@@ -4,7 +4,7 @@ import com.rollthedice.backend.domain.bookmark.service.BookmarkService;
 import com.rollthedice.backend.domain.member.entity.Member;
 import com.rollthedice.backend.domain.news.dto.response.NewsDetailResponse;
 import com.rollthedice.backend.domain.news.dto.response.ReadNewsResponse;
-import com.rollthedice.backend.domain.news.entity.ReadNews;
+import com.rollthedice.backend.domain.readNews.entity.ReadNews;
 import com.rollthedice.backend.domain.news.exception.NewsNotFoundException;
 import com.rollthedice.backend.domain.news.repository.ReadNewsRepository;
 import com.rollthedice.backend.global.oauth2.service.AuthService;
@@ -30,11 +30,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class NewsService {
     private final AuthService authService;
+    private final BookmarkService bookmarkService;
     private final ContentProducer contentProducer;
     private final NewsRepository newsRepository;
     private final ReadNewsRepository readNewsRepository;
     private final NewsMapper newsMapper;
-    private final BookmarkService bookmarkService;
 
 
     @Transactional

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/api/ReadNewsApi.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/api/ReadNewsApi.java
@@ -1,0 +1,22 @@
+package com.rollthedice.backend.domain.readNews.api;
+
+import com.rollthedice.backend.domain.news.dto.response.ReadNewsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.util.List;
+
+public interface ReadNewsApi {
+    @Operation(
+            summary = "최근 읽은 뉴스 조회",
+            description = "가장 최근에 읽은 3개의 뉴스를 조회합니다.",
+            security = {@SecurityRequirement(name = "access_token")},
+            tags = {"news"}
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "요청에 성공하였습니다."
+    )
+    List<ReadNewsResponse> getReadNews();
+}

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/api/ReadNewsController.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/api/ReadNewsController.java
@@ -1,0 +1,27 @@
+package com.rollthedice.backend.domain.readNews.api;
+
+import com.rollthedice.backend.domain.news.dto.response.ReadNewsResponse;
+import com.rollthedice.backend.domain.readNews.service.ReadNewsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("read-news")
+public class ReadNewsController implements ReadNewsApi {
+
+    private final ReadNewsService readNewsService;
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/viewed-history")
+    @Override
+    public List<ReadNewsResponse> getReadNews() {
+        return readNewsService.getReadNews();
+    }
+}

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/entity/ReadNews.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/entity/ReadNews.java
@@ -1,6 +1,7 @@
-package com.rollthedice.backend.domain.news.entity;
+package com.rollthedice.backend.domain.readNews.entity;
 
 import com.rollthedice.backend.domain.member.entity.Member;
+import com.rollthedice.backend.domain.news.entity.News;
 import com.rollthedice.backend.global.config.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/service/ReadNewsService.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/service/ReadNewsService.java
@@ -22,6 +22,6 @@ public class ReadNewsService {
     public List<ReadNewsResponse> getReadNews() {
         Member member = authService.getMember();
         List<ReadNews> readNews = readNewsReository.getTop3ByMemberOrderByCreatedAtDesc(member);
-        return newsService.getNewsByReadNews(readNews.stream().map(r -> r.getNews()).collect(Collectors.toList()));
+        return newsService.getNewsByReadNews(readNews.stream().map(ReadNews::getNews).collect(Collectors.toList()));
     }
 }

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/service/ReadNewsService.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/readNews/service/ReadNewsService.java
@@ -1,9 +1,10 @@
-package com.rollthedice.backend.domain.news.service;
+package com.rollthedice.backend.domain.readNews.service;
 
 import com.rollthedice.backend.domain.member.entity.Member;
 import com.rollthedice.backend.domain.news.dto.response.ReadNewsResponse;
-import com.rollthedice.backend.domain.news.entity.ReadNews;
+import com.rollthedice.backend.domain.readNews.entity.ReadNews;
 import com.rollthedice.backend.domain.news.repository.ReadNewsRepository;
+import com.rollthedice.backend.domain.news.service.NewsService;
 import com.rollthedice.backend.global.oauth2.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/backend/core/src/main/java/com/rollthedice/backend/domain/statistics/repository/ReadNewsCustomRepositoryImpl.java
+++ b/backend/core/src/main/java/com/rollthedice/backend/domain/statistics/repository/ReadNewsCustomRepositoryImpl.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import java.time.LocalDate;
 
 import static com.rollthedice.backend.domain.news.entity.QNews.news;
-import static com.rollthedice.backend.domain.news.entity.QReadNews.readNews;
+import static com.rollthedice.backend.domain.readNews.entity.QReadNews.readNews;
 
 @RequiredArgsConstructor
 public class ReadNewsCustomRepositoryImpl implements ReadNewsCustomRepository {

--- a/backend/core/src/test/java/com/rollthedice/backend/domain/news/api/NewsControllerTest.java
+++ b/backend/core/src/test/java/com/rollthedice/backend/domain/news/api/NewsControllerTest.java
@@ -3,7 +3,7 @@ package com.rollthedice.backend.domain.news.api;
 import com.rollthedice.backend.domain.news.exception.NewsNotFoundException;
 import com.rollthedice.backend.domain.news.repository.NewsRepository;
 import com.rollthedice.backend.domain.news.service.NewsService;
-import com.rollthedice.backend.domain.news.service.ReadNewsService;
+import com.rollthedice.backend.domain.readNews.service.ReadNewsService;
 import com.rollthedice.backend.global.BaseControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -82,7 +82,7 @@ class NewsControllerTest extends BaseControllerTest {
     void getReadNews() throws Exception{
         //when
         final ResultActions perform = mockMvc.perform(
-                get("/news/viewed-history")
+                get("/read-news/viewed-history")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("Authorization", "Bearer " + accessToken)
         ).andDo(print());

--- a/backend/core/src/test/java/com/rollthedice/backend/domain/news/api/NewsControllerTest.java
+++ b/backend/core/src/test/java/com/rollthedice/backend/domain/news/api/NewsControllerTest.java
@@ -25,10 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class NewsControllerTest extends BaseControllerTest {
     @MockBean
     private NewsService newsService;
-    @MockBean
-    private ReadNewsService readNewsService;
-    @MockBean
-    private NewsRepository newsRepository;
 
     @Test
     @DisplayName("News 전체 조회 API가 수행되는가")
@@ -75,19 +71,5 @@ class NewsControllerTest extends BaseControllerTest {
         //then
         perform.andExpect(status().isNotFound())
                 .andExpect(jsonPath(ERROR_MESSAGE, NEWS_NOT_FOUND_ERROR.getErrorMessage()).exists());
-    }
-
-    @Test
-    @DisplayName("조회한 News 전체 조회 API가 수행되는가")
-    void getReadNews() throws Exception{
-        //when
-        final ResultActions perform = mockMvc.perform(
-                get("/read-news/viewed-history")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header("Authorization", "Bearer " + accessToken)
-        ).andDo(print());
-
-        //then
-        perform.andExpect(status().isOk());
     }
 }

--- a/backend/core/src/test/java/com/rollthedice/backend/domain/news/repository/ReadNewsRepositoryTest.java
+++ b/backend/core/src/test/java/com/rollthedice/backend/domain/news/repository/ReadNewsRepositoryTest.java
@@ -4,7 +4,7 @@ import com.rollthedice.backend.domain.member.entity.Member;
 import com.rollthedice.backend.domain.member.repository.MemberRepository;
 import com.rollthedice.backend.domain.news.entity.News;
 import com.rollthedice.backend.domain.news.entity.NewsCategory;
-import com.rollthedice.backend.domain.news.entity.ReadNews;
+import com.rollthedice.backend.domain.readNews.entity.ReadNews;
 import com.rollthedice.backend.support.RepositoryTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/core/src/test/java/com/rollthedice/backend/domain/news/service/NewsServiceTest.java
+++ b/backend/core/src/test/java/com/rollthedice/backend/domain/news/service/NewsServiceTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -33,7 +32,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
-@Slf4j
 @DisplayName("NewsService의")
 @ExtendWith(MockitoExtension.class)
 class NewsServiceTest extends LoginTest {
@@ -44,11 +42,7 @@ class NewsServiceTest extends LoginTest {
     @MockBean
     private NewsRepository newsRepository;
     @MockBean
-    private BookmarkRepository bookmarkRepository;
-    @MockBean
     private ReadNewsRepository readNewsRepository;
-    @Mock
-    private NewsMapper newsMapper;
 
     private News news;
 
@@ -87,7 +81,7 @@ class NewsServiceTest extends LoginTest {
     }
 
     @Test
-    @DisplayName("뉴스를 상세조회할 수 있는가")
+    @DisplayName("뉴스를 상세 조회할 수 있는가")
     void getDetailNews() {
         //given
         NewsDetailResponse expect = NEWS_DETAIL_RESPONSE();

--- a/backend/core/src/test/java/com/rollthedice/backend/domain/readNews/ReadNewsFixture.java
+++ b/backend/core/src/test/java/com/rollthedice/backend/domain/readNews/ReadNewsFixture.java
@@ -1,0 +1,23 @@
+package com.rollthedice.backend.domain.readNews;
+
+import com.rollthedice.backend.domain.member.entity.Member;
+import com.rollthedice.backend.domain.news.dto.response.ReadNewsResponse;
+import com.rollthedice.backend.domain.readNews.entity.ReadNews;
+
+import static com.rollthedice.backend.domain.news.NewsFixture.NEWS;
+
+public class ReadNewsFixture {
+    public static ReadNews READ_NEWS(Member member) {
+        return ReadNews.builder()
+                .member(member)
+                .news(NEWS(member))
+                .build();
+    }
+
+    public static ReadNewsResponse READ_NEWS_RESPONSE() {
+        return ReadNewsResponse.builder()
+                .id(1L)
+                .title("임연지 대통령 되다.")
+                .build();
+    }
+}

--- a/backend/core/src/test/java/com/rollthedice/backend/domain/readNews/api/ReadNewsControllerTest.java
+++ b/backend/core/src/test/java/com/rollthedice/backend/domain/readNews/api/ReadNewsControllerTest.java
@@ -1,0 +1,35 @@
+package com.rollthedice.backend.domain.readNews.api;
+
+import com.rollthedice.backend.domain.readNews.service.ReadNewsService;
+import com.rollthedice.backend.global.BaseControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("ReadNewsController의 ")
+@WebMvcTest(ReadNewsController.class)
+class ReadNewsControllerTest extends BaseControllerTest {
+    @MockBean
+    private ReadNewsService readNewsService;
+
+    @Test
+    @DisplayName("조회한 News 전체 조회 API가 수행되는가")
+    void getReadNews() throws Exception{
+        //when
+        final ResultActions perform = mockMvc.perform(
+                get("/read-news/viewed-history")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("Authorization", "Bearer " + accessToken)
+        ).andDo(print());
+
+        //then
+        perform.andExpect(status().isOk());
+    }
+}

--- a/backend/core/src/test/java/com/rollthedice/backend/domain/readNews/repository/ReadNewsRepositoryTest.java
+++ b/backend/core/src/test/java/com/rollthedice/backend/domain/readNews/repository/ReadNewsRepositoryTest.java
@@ -1,9 +1,11 @@
-package com.rollthedice.backend.domain.news.repository;
+package com.rollthedice.backend.domain.readNews.repository;
 
 import com.rollthedice.backend.domain.member.entity.Member;
 import com.rollthedice.backend.domain.member.repository.MemberRepository;
 import com.rollthedice.backend.domain.news.entity.News;
 import com.rollthedice.backend.domain.news.entity.NewsCategory;
+import com.rollthedice.backend.domain.news.repository.NewsRepository;
+import com.rollthedice.backend.domain.news.repository.ReadNewsRepository;
 import com.rollthedice.backend.domain.readNews.entity.ReadNews;
 import com.rollthedice.backend.support.RepositoryTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("ReadNewsRepository의 ")
 @RepositoryTest
-public class ReadNewsRepositoryTest {
+class ReadNewsRepositoryTest {
     @Autowired
     private ReadNewsRepository readNewsRepository;
     @Autowired


### PR DESCRIPTION
## PULL REQUEST

### 🎋 작업중인 브랜치

- #166 

### ⚡️ 작업동기

- ReadNews와 News 도메인 분리

### 🔑 주요 변경사항

- ReadNews와 News 도메인 분리

### 💡 관련 이슈

close #166 